### PR TITLE
Add typography utilities with CSS tokens

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,10 +13,33 @@
   --color-accent-yellow: oklch(78.46% 0.165273 75.3442); 
   --color-accent-red: oklch(60.95% 0.2056 29.03); 
   --color-accent-brown: oklch(38.06% 0.0819 55.12); 
-  --color-secondary-1: oklch(40.81% 0.0852 154.17); 
-  --color-secondary-2: oklch(37.82% 0.1445 30.8); 
+  --color-secondary-1: oklch(40.81% 0.0852 154.17);
+  --color-secondary-2: oklch(37.82% 0.1445 30.8);
+
+  /* Typography */
+  --fs-h1: 3.052rem;
+  --fs-h2: 2.441rem;
+  --fs-h3: 1.953rem;
+  --fs-h4: 1.563rem;
+  --fs-h5: 1.25rem;
+  --fs-h6: 1rem;
+  --fs-p: 1rem;
+  --fs-small: .8rem;
+  --fs-quote: 1.25rem;
 }
 
 :root {
   @apply font-outfit text-dark bg-light antialiased;
+}
+
+@layer utilities {
+  .text-h1   { font-size: var(--fs-h1); line-height: 1.33; font-weight: 700; }
+  .text-h2   { font-size: var(--fs-h2); line-height: 1.33; font-weight: 600; }
+  .text-h3   { font-size: var(--fs-h3); line-height: 1.33; font-weight: 600; }
+  .text-h4   { font-size: var(--fs-h4); line-height: 1.33; font-weight: 600; }
+  .text-h5   { font-size: var(--fs-h5); line-height: 1.33; font-weight: 600; }
+  .text-h6   { font-size: var(--fs-h6); line-height: 1.33; font-weight: 600; }
+  .text-p    { font-size: var(--fs-p);  line-height: 1.75; font-weight: 300; }
+  .text-small{ font-size: var(--fs-small); line-height: 1.75; }
+  .text-quote{ font-size: var(--fs-quote); line-height: 1.75; }
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -3,20 +3,6 @@ import defaultTheme from "tailwindcss/defaultTheme";
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
-  theme: {
-    extend: {
-      fontSize: {
-        h1: ["3.052rem", { lineHeight: "1.33", fontWeight: "700" }], // 48.83px
-        h2: ["2.441rem", { lineHeight: "1.33", fontWeight: "600" }], // 39.06px
-        h3: ["1.953rem", { lineHeight: "1.33", fontWeight: "600" }], // 31.25px
-        h4: ["1.563rem", { lineHeight: "1.33", fontWeight: "600" }], // 25px
-        h5: ["1.25rem", { lineHeight: "1.33", fontWeight: "600" }], // 20px
-        h6: ["1rem", { lineHeight: "1.33", fontWeight: "600" }], // 16px
-        p: ["1rem", { lineHeight: "1.75", fontWeight: "300" }], // 16px
-        small: [".8rem", { lineHeight: "1.75" }], // 12.8px
-        quote: ["1.25rem", { lineHeight: "1.75" }], // 20px
-      },
-    },
-  },
+  theme: {},
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- remove Tailwind `fontSize` extension
- expose typography sizes as CSS custom properties
- add utility classes for headings, text, and quotes

## Testing
- `npm run build`
